### PR TITLE
Use room_resolve_alias() for room env variables

### DIFF
--- a/nullbot.py
+++ b/nullbot.py
@@ -1,6 +1,7 @@
 import asyncio
 from dataclasses import dataclass
 from nio import AsyncClient
+from nio.rooms import MatrixRoom
 import os
 import asyncpg
 import pkgutil
@@ -29,6 +30,9 @@ class NullBot:
                 asyncio.create_task(register(self))
 
         await self.client.sync_forever(timeout=3000, full_state=True)
+
+    def room_from_id(self, room_id):
+        return MatrixRoom(room_id, self.client.user_id)
 
     async def send_room(self, room, message):
         await self.client.room_send(

--- a/plugin/choose.py
+++ b/plugin/choose.py
@@ -5,18 +5,10 @@ import re
 
 choose_re = re.compile(r'!choose (.+)')
 
-async def message_cb(client, room, event):
+async def message_cb(bot, room, event):
     if (match := choose_re.fullmatch(event.body)) is not None:
         choice = random.choice(match.group(1).split(','))
-
-        await client.room_send(
-            room_id=room.room_id,
-            message_type='m.room.message',
-            content={
-                'msgtype': 'm.text',
-                'body': f'{choice}',
-            }
-        )
+        await bot.send_room(room, choice)
 
 async def register(bot):
-    bot.client.add_event_callback(partial(message_cb, bot.client), RoomMessageText)
+    bot.client.add_event_callback(partial(message_cb, bot), RoomMessageText)


### PR DESCRIPTION
This lets us pass human friendly room names as environment variables,
which get resolved by nio. Since the room_resolve_alias(...) returns a
room_id, add a small helper function to the bot to convert a room_id to
a MatrixRoom object.

This allows us to make use of the send_room method in monitor_streams().

Also have !choose use bot.send_room(...)